### PR TITLE
Fixed French TTS pronouns with apostrophes

### DIFF
--- a/public/js/offline-db.js
+++ b/public/js/offline-db.js
@@ -222,7 +222,8 @@
 
     // Decoys
     const others = _shuffle(pool.filter(w => w.id !== question.id)).slice(0, 3).map(w => {
-      const wd = (w.article ? w.article + ' ' : '') + (w.type === 'verb' && w.infinitive ? w.infinitive : w.literal);
+      const sep = w.article && (w.article.endsWith("'") || w.article.endsWith("\u2019")) ? '' : ' ';
+      const wd = (w.article ? w.article + sep : '') + (w.type === 'verb' && w.infinitive ? w.infinitive : w.literal);
       return showNative ? wd : w.translation;
     });
     const choices = _shuffle([answerText, ...others]);

--- a/public/js/offline.js
+++ b/public/js/offline.js
@@ -112,7 +112,8 @@ window.Offline = (() => {
       const words   = entries.find(e => e.key === `/api/words?lang=${lang}`)?.value || [];
       const phrases = entries.find(e => e.key === `/api/phrases?lang=${lang}`)?.value || [];
       for (const w of words) {
-        const text = (w.article ? w.article + ' ' : '') + (w.type === 'verb' && w.infinitive ? w.infinitive : w.literal);
+        const sep = w.article && (w.article.endsWith("'") || w.article.endsWith("\u2019")) ? '' : ' ';
+        const text = (w.article ? w.article + sep : '') + (w.type === 'verb' && w.infinitive ? w.infinitive : w.literal);
         ttsTasks.push(`/api/tts?lang=${lang}&q=${encodeURIComponent(text)}&id=${w.id}&speed=${speedNormal}`);
         ttsTasks.push(`/api/tts?lang=${lang}&q=${encodeURIComponent(text)}&id=${w.id}&speed=${speedSlow}`);
       }

--- a/public/js/pages/vocabulary.js
+++ b/public/js/pages/vocabulary.js
@@ -248,7 +248,8 @@ function getLabels() {
 
 function buildWordCard(w) {
   const labels = { noun: `📦 ${t('vocab_noun')}`, verb: `⚡ ${t('vocab_verb')}`, adjective: `🎨 ${t('vocab_adjective')}`, adverb: `💨 ${t('vocab_adverb')}` };
-  const display = (w.article ? w.article + ' ' : '') + (w.type === 'verb' && w.infinitive ? w.infinitive : w.literal);
+  const sep = w.article && (w.article.endsWith("'") || w.article.endsWith("\u2019")) ? '' : ' ';
+  const display = (w.article ? w.article + sep : '') + (w.type === 'verb' && w.infinitive ? w.infinitive : w.literal);
   const progress = w.progress || 0;
   const maxProg = w.maxProgress || wordMaxProgressClient(w.literal, w.infinitive);
   const mastered = progress >= maxProg;

--- a/src/routes/admin.js
+++ b/src/routes/admin.js
@@ -5,7 +5,7 @@ const { randomUUID } = require('crypto');
 const { getUsers, saveUsers, getUserConfig, saveUserConfig, getWords, getPhrases } = require('../utils/storage');
 const { requireAdmin } = require('../middleware/auth');
 const { purgeCache, cacheStats, getCached, saveCachedBuffer } = require('../utils/tts-cache');
-const { bufferTTS } = require('../utils/tts-generate');
+const { bufferTTS, wordDisplay } = require('../utils/tts-generate');
 
 router.use(requireAdmin);
 
@@ -159,8 +159,7 @@ router.post('/users/:id/tts-cache/generate', async (req, res) => {
       const words   = getWords(uid, lang.isoCode);
       const phrases = getPhrases(uid, lang.isoCode);
       for (const w of words) {
-        const display = (w.article ? w.article + ' ' : '') +
-          (w.type === 'verb' && w.infinitive ? w.infinitive : w.literal);
+        const display = wordDisplay(w);
         tasks.push({ text: display, id: w.id, mode: 'normal', speed: speedNormal, lang: lang.isoCode });
         tasks.push({ text: display, id: w.id, mode: 'slow',   speed: speedSlow,   lang: lang.isoCode });
       }

--- a/src/routes/api.js
+++ b/src/routes/api.js
@@ -44,7 +44,7 @@ const {
 const {
   getCached, saveCachedBuffer, pipeToCache, purgeCache, cacheStats, textHash, deleteItem, deleteItemAllSpeeds
 } = require('../utils/tts-cache');
-const { bufferTTS: _sharedBufferTTS, EDGE_TTS_VOICES: _sharedVoices } = require('../utils/tts-generate');
+const { bufferTTS: _sharedBufferTTS, EDGE_TTS_VOICES: _sharedVoices, wordDisplay } = require('../utils/tts-generate');
 
 // ─────────────────────────────────────────────────────────────────────────────
 // HELPERS
@@ -450,8 +450,7 @@ router.post('/tts/generate', async (req, res) => {
     // Build task list
     const tasks = [];
     for (const w of words) {
-      const display = (w.article ? w.article + ' ' : '') +
-        (w.type === 'verb' && w.infinitive ? w.infinitive : w.literal);
+      const display = wordDisplay(w);
       tasks.push({
         text: display, id: w.id, mode: 'normal', speed: numNormal,
         prevSpeed: normalChanged ? prevNorm : null
@@ -696,9 +695,7 @@ router.get('/quiz', (req, res) => {
       : Math.random() < 0.5;
 
   // For verbs with conjugation: randomly decide to quiz on a specific conjugated form
-  let display = (question.article && question.article.trim())
-    ? `${question.article} ${question.literal}`
-    : (question.type === 'verb' && question.infinitive ? question.infinitive : question.literal);
+  let display = wordDisplay(question);
 
   let promptText, answerText;
   let quizPronoun = null;  // set if quizzing on a specific conjugated form
@@ -732,7 +729,7 @@ router.get('/quiz', (req, res) => {
   const others = pool.filter(w => w.id !== question.id);
   shuffle(others);
   const decoys = others.slice(0, 3).map(w => {
-    const wDisplay = (w.article ? w.article + ' ' : '') + (w.type === 'verb' && w.infinitive ? w.infinitive : w.literal);
+    const wDisplay = wordDisplay(w);
     return showNative ? wDisplay : w.translation;
   });
 
@@ -769,7 +766,7 @@ router.post('/quiz/answer', (req, res) => {
   if (idx === -1) return res.status(404).json({ error: 'Word not found.' });
 
   const w = words[idx];
-  const display = (w.article ? w.article + ' ' : '') + (w.type === 'verb' && w.infinitive ? w.infinitive : w.literal);
+  const display = wordDisplay(w);
   const correct = answer && (
     w.translation.trim().toLowerCase() === answer.trim().toLowerCase() ||
     display.trim().toLowerCase() === answer.trim().toLowerCase() ||

--- a/src/utils/tts-generate.js
+++ b/src/utils/tts-generate.js
@@ -33,6 +33,13 @@ const EDGE_TTS_VOICES = {
   'cy':'cy-GB-NiaNeural'
 };
 
+function wordDisplay(w) {
+  const article = w.article || '';
+  const separator = article && !article.endsWith("'") && !article.endsWith("\u2019") ? ' ' : '';
+  return (article ? article + separator : '') +
+    (w.type === 'verb' && w.infinitive ? w.infinitive : w.literal);
+}
+
 function speedToEdgeRate(speed) {
   const pct = Math.round(speed * 100);
   return pct >= 100 ? `+${pct - 100}%` : `-${100 - pct}%`;
@@ -86,4 +93,4 @@ async function bufferTTS(text, langCode, speed) {
   });
 }
 
-module.exports = { bufferTTS, EDGE_TTS_VOICES };
+module.exports = { bufferTTS, EDGE_TTS_VOICES, wordDisplay };


### PR DESCRIPTION
## What's new
- For pronouns with apostrophes, the pronouns is appened to the name (no space between)
- Fix #68 
- The Ukrainian problem with **м'ята** comes from Microsoft's TTS service and not the app (tested directly on **Bing Translator** https://www.bing.com/translator)