### PR TITLE
Fixed "Add this word" that was saved as a verb

### DIFF
--- a/public/js/pages/add.js
+++ b/public/js/pages/add.js
@@ -2,6 +2,7 @@
 'use strict';
 
 function renderAdd(el) {
+  window._addWordType = 'noun';
   const lang = currentLang();
   if (!lang) { navigate('settings'); return; }
 


### PR DESCRIPTION
## What's new

- Bugfix where adding a non existing word from **vocabulary.js** would create it as a verb and not a noun by default
- This fixes #90 